### PR TITLE
fix: use pyfmtools from pypi

### DIFF
--- a/.github/workflows/test-master.yml
+++ b/.github/workflows/test-master.yml
@@ -49,6 +49,10 @@ jobs:
     - name: Install Hatch
       run: pip install --upgrade hatch
 
+    - if: runner.os == 'Linux'
+      name: Install pip dependencies
+      run: CPPFLAGS="-std=c++11" hatch env create # For some reason eport CPPFLAGS="-std=c++11" doesn't work so doing this to install pip dependecies with c++11
+
     - if: matrix.python-version == '3.9' && runner.os == 'Linux'
       name: Type check
       run: hatch run types:check      

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,12 @@ jobs:
     - name: Install Hatch
       run: pip install --upgrade hatch
 
+    - name: Install pip dependencies
+      run: CPPFLAGS="-std=c++11" hatch env create # For some reason eport CPPFLAGS="-std=c++11" doesn't work so doing this to install pip dependecies with c++11
+
     - if: matrix.python-version == '3.9' && runner.os == 'Linux'
       name: Type check
-      run: hatch run types:check      
+      run: hatch run types:check
 
     - if: matrix.python-version == '3.9' && runner.os == 'Linux'
       name: Lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "pplpy==0.8.9; platform_system != 'Windows'",
   "gmpy2==2.1.5; platform_system != 'Windows'",
   "cysignals==1.11.4; platform_system != 'Windows'",
-  "pyfmtools @ git+https://github.com/furadnik/fmtools-fix ; platform_system == 'Linux'",
+  "pyfmtools==0.81; platform_system == 'Linux'",
 ]
 
 [project.urls]


### PR DESCRIPTION
I managed to successfully compile the pyfmtools on MacOS and Linux using the pypi version. This also make possible to publish this library to pypi, which does not support direct dependecies.

Although locally everything worked on MacOS, workflows did not passed. So postponing support for Mac for now.

- Related: #36 