### PR TITLE
Git/publish to testpypi fix

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -93,6 +93,7 @@ jobs:
 
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
+    if: github.ref == 'refs/heads/master'  # Run only on the master branch
     needs:
     - build
     runs-on: ubuntu-latest

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,15 @@
+0.1.3
+-----
+
+🚀 New Features
+  • Nothing
+
+💥 Breaking Changes
+  • Nothing
+
+🐛 Bug Fixes
+  • fix publishing workflow to publish to testpypi just on push to master branch
+
 0.1.2
 -----
 

--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,7 @@
 
 🐛 Bug Fixes
   • fix publishing workflow to publish to testpypi just on push to master branch
+  • fix links in README
 
 0.1.2
 -----

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 A python library for cooperative game theory
 
 
-[![PyPI - Version](https://img.shields.io/pypi/v/Shapleypy.svg)](https://pypi.org/project/Shapleypy)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/Shapleypy.svg)](https://pypi.org/project/Shapleypy)
+[![PyPI - Version](https://img.shields.io/pypi/v/shapleypy.svg)](https://pypi.org/project/shapleypy)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/shapleypy.svg)](https://pypi.org/project/shapleypy)
 ![Test](https://github.com/muzikr/Shapleypy/actions/workflows/test-master.yml/badge.svg)
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 


### PR DESCRIPTION
Current workflow would publish new version on push to every branch in the repository. This does not make sense since these branches are usually used for development and are very unstable. I would like to use testpypi to provide version that will be in next released and is tested by developer.

Also I noticed mistake in link, so fixing that too.