### PR TITLE
Drop of convex game generator and introduction of support of python 3.12

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: hatch build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -62,7 +62,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/

--- a/README.md
+++ b/README.md
@@ -48,22 +48,8 @@ pip install -i https://test.pypi.org/simple/ shapleypy
 
 ### Linux
 
-To install this package for Linux you need to set ```$CPPFLAGS``` to contain ```-std=c++11```. This can be achieve by
 
-```bash
-export CPPFLAGS="-std=c++11 $CPPFLAGS"
-```
-> [!NOTE]
-> We know that ```CPPFLAGS``` are not meant for C++, but ```CXXFLAGS``` are not suported by setuptools.
-
-or by running the installation in form of
-
-```bash
-CPPFLAGS="-std=c++11" pip install shapleypy
-```
-not to make the standart pernament.
-
-Also there are some non-python dependencies. Those could be installed via distribution package manager.
+Few non-python dependencies have to be installed prior the installation of the __Shapleypy__. Those could be installed via distribution package manager.
 
 Ubuntu:
 ```bash
@@ -72,9 +58,6 @@ sudo apt-get install -y ppl-dev libgmp-dev libmpfr-dev libmpc-dev
 
 
 ### MacOS
-
-> [!WARNING]
-> Convex game generator is currently not available for MacOS
 
 There are some non-python requirements. These could be installed via homebrew:
 
@@ -89,7 +72,7 @@ brew install ppl gmp mpfr libmpc
 ### Windows
 
 > [!WARNING]
-> Convex game generator and core solution concept are currently not available for Windows
+> The core solution concept is currently not available for Windows.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -58,7 +59,7 @@ cov = [
 ]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.9", "3.10", "3.11"]
+python = ["3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.types]
 extra-dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,9 @@ classifiers = [
 ]
 dependencies = [
   "numpy",
-  "pplpy==0.8.9; platform_system != 'Windows'",
-  "gmpy2==2.1.5; platform_system != 'Windows'",
-  "cysignals==1.11.4; platform_system != 'Windows'",
+  "pplpy==0.8.10; platform_system != 'Windows'",
+  "gmpy2==2.2.1; platform_system != 'Windows'",
+  "cysignals==1.12.3; platform_system != 'Windows'",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
   "pplpy==0.8.9; platform_system != 'Windows'",
   "gmpy2==2.1.5; platform_system != 'Windows'",
   "cysignals==1.11.4; platform_system != 'Windows'",
-  "pyfmtools==0.81; platform_system == 'Linux'",
 ]
 
 [project.urls]

--- a/src/shapleypy/constants.py
+++ b/src/shapleypy/constants.py
@@ -30,7 +30,6 @@ CORE_WINDOWS_ERROR = """
     """
 POSITIVE_GAME_GENERATOR_LOWER_BOUND_ERROR = "lower_bound must be non-negative"
 K_GAMES_PARAMETER = "k must be between 1 and the number of players"
-CONVEX_GAME_GENERATOR_ERROR = "convex_game_generator is not available"
 
 # Warnings
 DEFAULT_VALUE_WARNING = "Warning: Unchanged default value is used in the game"

--- a/src/shapleypy/generators.py
+++ b/src/shapleypy/generators.py
@@ -5,9 +5,7 @@ from enum import Enum
 
 import numpy as np
 
-from shapleypy.classes_checkers import check_convexity
 from shapleypy.constants import (
-    CONVEX_GAME_GENERATOR_ERROR,
     K_GAMES_PARAMETER,
     POSITIVE_GAME_GENERATOR_LOWER_BOUND_ERROR,
 )
@@ -130,59 +128,6 @@ def positive_game_generator(
     )
 
     return _compute_game_from_unanimity_game(m_v_game)
-
-
-# ruff: noqa: ARG001
-def convex_game_generator(
-    number_of_players: int,
-    generator: np.random.Generator = np.random.default_rng(),
-    return_type: ReturnType = ReturnType.FLOAT,
-    lower_bound: int = 0,
-    upper_bound: int = 1,
-) -> Game:
-    """
-    Generates a random convex game.
-
-    WARNING: This function is not optimal and will be changed in the future.
-             Even for relatively small number_of_players it takes quite a while
-             to compute. This function requires the 'pyfmtools' package to be
-             installed and is available only on Linux for time being.
-
-    Note: The only parameter that is used is the number_of_players. The others
-          are there so all the generators have the same arguments.
-
-    Args:
-        number_of_players (int): The number of players in the game.
-        generator (np.random.Generator): Random generator to use.
-        return_type (ReturnType): Type of the return value.
-            Either FLOAT or INTEGER.
-        lower_bound (int): Lower bound for the random number (included).
-        upper_bound (int): Upper bound for the random number (excluded).
-
-    Returns:
-        Game: The generated convex game.
-    """
-    try:
-        import pyfmtools as fmp  # type: ignore[import-untyped]
-    except ModuleNotFoundError:
-        raise ImportError(CONVEX_GAME_GENERATOR_ERROR) from None
-
-    env = fmp.fm_init(number_of_players)
-
-    game = Game(number_of_players)
-    while True:
-        _, values = fmp.generate_fmconvex_tsort(
-            1, number_of_players, number_of_players - 1, 1000, 1, 1000, env
-        )
-        converted_values = fmp.ConvertCard2Bit(values, env)
-        if fmp.IsMeasureSupermodular(converted_values, env):
-            game.set_values(list(zip(game.all_coalitions, converted_values)))
-            if check_convexity(game):
-                break
-
-    fmp.fm_free(env)
-
-    return game
 
 
 def k_game_generator(

--- a/src/shapleypy/solution_concept/core.py
+++ b/src/shapleypy/solution_concept/core.py
@@ -63,10 +63,7 @@ def _get_polyhedron_of_game(
     )[0].as_integer_ratio()
     constrain_system.insert(
         ppl.Linear_Expression(
-            {
-                player: 1 * denominator
-                for player in range(game.number_of_players)
-            },
+            dict.fromkeys(range(game.number_of_players), 1 * denominator),
             0,
         )
         == numerator
@@ -78,7 +75,7 @@ def _get_polyhedron_of_game(
         )[0].as_integer_ratio()
         constrain_system.insert(
             ppl.Linear_Expression(
-                {player: 1 * denominator for player in coalition.get_players}, 0
+                dict.fromkeys(coalition.get_players, 1 * denominator), 0
             )
             >= numerator
         )

--- a/tests/test_banzhaf_value.py
+++ b/tests/test_banzhaf_value.py
@@ -39,7 +39,7 @@ def basic_values_for_game_of_three_with_missing_values() -> (
 
 
 def test_banzhaf_value_of_player(
-    basic_values_for_game_of_three: list[tuple[Coalition, float]]
+    basic_values_for_game_of_three: list[tuple[Coalition, float]],
 ) -> None:
     game = Game(3)
     game.set_values(basic_values_for_game_of_three)
@@ -49,7 +49,7 @@ def test_banzhaf_value_of_player(
 
 
 def test_banzhaf_value_of_game(
-    basic_values_for_game_of_three: list[tuple[Coalition, float]]
+    basic_values_for_game_of_three: list[tuple[Coalition, float]],
 ) -> None:
     game = Game(3)
     game.set_values(basic_values_for_game_of_three)
@@ -60,7 +60,7 @@ def test_banzhaf_value_of_game(
 def test_banzhaf_value_of_game_with_default_value(
     basic_values_for_game_of_three_with_missing_values: list[
         tuple[Coalition, float]
-    ]
+    ],
 ) -> None:
     game = Game(3)
     game.set_values(basic_values_for_game_of_three_with_missing_values)
@@ -70,7 +70,7 @@ def test_banzhaf_value_of_game_with_default_value(
 def test_banzhaf_value_of_game_with_default_value_warning(
     basic_values_for_game_of_three_with_missing_values: list[
         tuple[Coalition, float]
-    ]
+    ],
 ) -> None:
     """
     If user did not set the default value parameter, he probably missed a
@@ -85,7 +85,7 @@ def test_banzhaf_value_of_game_with_default_value_warning(
 def test_banzhaf_value_of_game_with_default_value_without_warning(
     basic_values_for_game_of_three_with_missing_values: list[
         tuple[Coalition, float]
-    ]
+    ],
 ) -> None:
     """
     If user set the default value parameter to the default value, he probably
@@ -103,7 +103,7 @@ def test_banzhaf_value_of_game_with_default_value_without_warning(
 def test_banzhaf_value_of_game_with_set_default_value(
     basic_values_for_game_of_three_with_missing_values: list[
         tuple[Coalition, float]
-    ]
+    ],
 ) -> None:
     game = Game(3)
     game.set_values(basic_values_for_game_of_three_with_missing_values)

--- a/tests/test_classes_checkers.py
+++ b/tests/test_classes_checkers.py
@@ -61,7 +61,7 @@ def k_game_of_three() -> list[tuple[Coalition, float]]:
 
 
 def test_check_monotonicity(
-    monotone_game_of_three: list[tuple[Coalition, float]]
+    monotone_game_of_three: list[tuple[Coalition, float]],
 ) -> None:
     game = Game(3)
     game.set_values(monotone_game_of_three)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -90,7 +90,7 @@ def test_get_vertices(
 
 
 def test_contain_integer_point(
-    game_of_three_values_non_empty_core: list[tuple[Coalition, float]]
+    game_of_three_values_non_empty_core: list[tuple[Coalition, float]],
 ) -> None:
     game = Game(3)
     game.set_values(game_of_three_values_non_empty_core)

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -97,7 +97,7 @@ def test_set_values_from_coalition_form(
 
 
 def test_set_values_from_str_form(
-    basic_values_for_game_of_three_list_form: list[tuple[list[int], float]]
+    basic_values_for_game_of_three_list_form: list[tuple[list[int], float]],
 ) -> None:
     game = Game(3)
     game.set_values(basic_values_for_game_of_three_list_form)
@@ -118,7 +118,9 @@ def test_get_value() -> None:
 
 
 def test_get_values(
-    basic_values_for_game_of_three_coalition_form: list[tuple[Coalition, float]]
+    basic_values_for_game_of_three_coalition_form: list[
+        tuple[Coalition, float]
+    ],
 ) -> None:
     game = Game(3)
     game.set_values(basic_values_for_game_of_three_coalition_form)
@@ -217,7 +219,9 @@ def test_get_values_out_of_bounds() -> None:
 
 
 def test_eq(
-    basic_values_for_game_of_three_coalition_form: list[tuple[Coalition, float]]
+    basic_values_for_game_of_three_coalition_form: list[
+        tuple[Coalition, float]
+    ],
 ) -> None:
     game1 = Game(3)
     game2 = Game(3)

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import sys
-
 import pytest
 
 from shapleypy.classes_checkers import (
-    check_convexity,
     check_k_additivity,
     check_k_game,
     check_positivity,
@@ -46,18 +43,6 @@ def test_positive_game_generator() -> None:
     assert check_positivity(game)
     with pytest.raises(ValueError):
         positive_game_generator(5, lower_bound=-1)
-
-
-@pytest.mark.skipif(
-    sys.platform != "linux", reason="convex_game_generator is not available"
-)
-def test_convex_game_generator() -> None:
-    # I was unable to properly set c++ flags to compile the extension for
-    # MacOS so skip this test if the extension is not available
-    from shapleypy.generators import convex_game_generator
-
-    game = convex_game_generator(5)
-    assert check_convexity(game)
 
 
 def test_k_game_generator() -> None:

--- a/tests/test_normallization.py
+++ b/tests/test_normallization.py
@@ -26,7 +26,9 @@ def basic_values_for_game_of_three_coalition_form() -> (
 
 
 def test_standart_normalization(
-    basic_values_for_game_of_three_coalition_form: list[tuple[Coalition, float]]
+    basic_values_for_game_of_three_coalition_form: list[
+        tuple[Coalition, float]
+    ],
 ) -> None:
     game = Game(3)
     game.set_values(basic_values_for_game_of_three_coalition_form)
@@ -39,7 +41,9 @@ def test_standart_normalization(
 
 
 def test_zero_one_normalization(
-    basic_values_for_game_of_three_coalition_form: list[tuple[Coalition, float]]
+    basic_values_for_game_of_three_coalition_form: list[
+        tuple[Coalition, float]
+    ],
 ) -> None:
     game = Game(3)
     game.set_values(basic_values_for_game_of_three_coalition_form)

--- a/tests/test_shapley_value.py
+++ b/tests/test_shapley_value.py
@@ -39,7 +39,7 @@ def basic_values_for_game_of_three_with_missing_values() -> (
 
 
 def test_shapley_value_of_player(
-    basic_values_for_game_of_three: list[tuple[Coalition, float]]
+    basic_values_for_game_of_three: list[tuple[Coalition, float]],
 ) -> None:
     game = Game(3)
     game.set_values(basic_values_for_game_of_three)
@@ -49,7 +49,7 @@ def test_shapley_value_of_player(
 
 
 def test_shapley_value_of_game(
-    basic_values_for_game_of_three: list[tuple[Coalition, float]]
+    basic_values_for_game_of_three: list[tuple[Coalition, float]],
 ) -> None:
     game = Game(3)
     game.set_values(basic_values_for_game_of_three)
@@ -60,7 +60,7 @@ def test_shapley_value_of_game(
 def test_shapley_value_of_game_with_default_value(
     basic_values_for_game_of_three_with_missing_values: list[
         tuple[Coalition, float]
-    ]
+    ],
 ) -> None:
     game = Game(3)
     game.set_values(basic_values_for_game_of_three_with_missing_values)
@@ -70,7 +70,7 @@ def test_shapley_value_of_game_with_default_value(
 def test_shapley_value_of_game_with_default_value_warning(
     basic_values_for_game_of_three_with_missing_values: list[
         tuple[Coalition, float]
-    ]
+    ],
 ) -> None:
     """
     If user did not set the default value parameter, he probably missed a
@@ -85,7 +85,7 @@ def test_shapley_value_of_game_with_default_value_warning(
 def test_shapley_value_of_game_with_default_value_without_warning(
     basic_values_for_game_of_three_with_missing_values: list[
         tuple[Coalition, float]
-    ]
+    ],
 ) -> None:
     """
     If user set the default value parameter to the default value, he probably
@@ -99,7 +99,7 @@ def test_shapley_value_of_game_with_default_value_without_warning(
 def test_shapley_value_of_game_with_set_default_value(
     basic_values_for_game_of_three_with_missing_values: list[
         tuple[Coalition, float]
-    ]
+    ],
 ) -> None:
     game = Game(3)
     game.set_values(basic_values_for_game_of_three_with_missing_values)


### PR DESCRIPTION
Let's drop the problematic convex game generator (the ``pyfmtools`` dependency really). With some updates of other dependencies this allows to use newer version of python.

Closes #36 #26